### PR TITLE
[FIX] PHP 7.3: Unparenthesized expressions

### DIFF
--- a/image_moo.php
+++ b/image_moo.php
@@ -807,7 +807,7 @@ class Image_moo
 		// check it
 		if(!is_resource($this->temp_image))
 		{
-			$this->set_error('Unable to create temp image sized '.$x2-$x1.' x '.$y2-$y1);
+			$this->set_error('Unable to create temp image sized '.($x2-$x1).' x '.($y2-$y1));
 			return $this;
 		}
 


### PR DESCRIPTION
PHP 7.3 raises a deprecation notice when the concat operator (.) and +/- operators are used in the same expression without parenthesis. This is to mitigate the code ambiguity, and to prepare to set the strict order of operators. From PHP 8 and later, this will be evaluated as 'total' + (5 + 5), with the + and - operators taking higher precedence.