### PR TITLE
fix unparenthesized expression

### DIFF
--- a/image_moo.php
+++ b/image_moo.php
@@ -807,7 +807,7 @@ class Image_moo
 		// check it
 		if(!is_resource($this->temp_image))
 		{
-			$this->set_error('Unable to create temp image sized '.$x2-$x1.' x '.$y2-$y1);
+			$this->set_error('Unable to create temp image sized '.($x2-$x1).' x '.($y2-$y1));
 			return $this;
 		}
 


### PR DESCRIPTION
fix the warning message:
"Deprecated: The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence"