### PR TITLE
Fix PHP 8 GD image compatibility

### DIFF
--- a/image_moo.php
+++ b/image_moo.php
@@ -216,7 +216,7 @@ class Image_moo
 	//----------------------------------------------------------------------------------------------------------
 	{
 		// generic check
-		if (!$this->($this->main_image))
+		if (!$this->is_gd_image($this->main_image))
 		{
 			$this->set_error("No main image loaded!");
 			return FALSE;


### PR DESCRIPTION
From PHP 8.0 and forward, GD extension uses \GdImage class objects instead of resource s for its underlying data structures.